### PR TITLE
Fixed writing data to authority server

### DIFF
--- a/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
+++ b/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
@@ -82,16 +82,15 @@ public final class BlockJamCorePlugin {
             connection.setRequestMethod("POST");
             byte[] params = ("key=" + key).getBytes(StandardCharsets.UTF_8);
             connection.setFixedLengthStreamingMode(params.length);
-            connection.connect();
-
+            OutputStream os = connection.getOutputStream();
+            os.write(params);
+            // connection.connect() can be omitted because getResponseCode() calls it automatically
             if (connection.getResponseCode() / 100 != 2) {
                 // this just gets caught down below
                 throw new IOException("Received bad response code from authority server ("
                         + connection.getResponseCode() + " " + connection.getResponseMessage() + ")");
             }
 
-            OutputStream os = connection.getOutputStream();
-            os.write(params);
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024];
             int i;


### PR DESCRIPTION
[SG](https://github.com/jamierocks/BlockJam-SurvivalGames/pull/1) | Core

Simply moved writing data before requesting a response. I also omitted the `connect()` because it is automatically called by `getResponseCode()`.
