### PR TITLE
Add BungeeCord manager

### DIFF
--- a/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
+++ b/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
@@ -27,6 +27,7 @@ package org.blockjam.core;
 import com.google.inject.Inject;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.blockjam.core.bungee.BungeeManager;
 import org.blockjam.core.config.ConfigKeys;
 import org.blockjam.core.config.ConfigManager;
 import org.spongepowered.api.config.DefaultConfig;
@@ -52,6 +53,7 @@ public final class BlockJamCorePlugin {
     @Inject @DefaultConfig(sharedRoot = false) private ConfigurationLoader<CommentedConfigurationNode> configLoader;
 
     private ConfigManager configManager;
+    private BungeeManager bungeeManager;
 
     @Listener
     public void onInitialization(GameInitializationEvent event) {
@@ -63,6 +65,8 @@ public final class BlockJamCorePlugin {
         } catch (IOException ex) {
             throw new RuntimeException("Failed to load config");
         }
+
+        bungeeManager = new BungeeManager();
     }
 
     public static BlockJamCorePlugin instance() {
@@ -71,6 +75,10 @@ public final class BlockJamCorePlugin {
 
     public static ConfigManager config() {
         return instance().configManager;
+    }
+
+    public static BungeeManager bungeeManager() {
+        return instance().bungeeManager;
     }
 
     public static byte[] getFromAuthority(String key) throws IOException {

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -57,7 +57,6 @@ public class BungeeManager {
      * @param server The server to transfer the {@link Player} to
      */
     public void transferPlayer(Player player, String server) {
-        checkNotNull(this.channel, "channel is null!");
         checkNotNull(player, "player is null!");
         checkNotNull(server, "server is null!");
         this.channel.sendTo(player, buf -> buf.writeUTF("Connect").writeUTF(server));
@@ -80,7 +79,6 @@ public class BungeeManager {
      * @param server The server to transfer the {@link Player}s to
      */
     public void transferAllPlayers(String server) {
-        checkNotNull(this.channel, "channel is null!");
         checkNotNull(server, "server is null!");
         this.channel.sendToAll(buf -> buf.writeUTF("Connect").writeUTF(server));
     }
@@ -135,7 +133,6 @@ public class BungeeManager {
      * @param reason The reason
      */
     public void kickPlayer(Player player, String reason) {
-        checkNotNull(this.channel, "channel is null!");
         checkNotNull(player, "player is null!");
         checkNotNull(reason, "reason is null!");
         this.channel.sendTo(player, buf -> buf.writeUTF("KickPlayer").writeUTF(player.getName()).writeUTF(reason));

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of BlockJamCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, BlockJam <https://blockjam.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.blockjam.core.bungee;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.blockjam.core.BlockJamCorePlugin;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.network.ChannelBinding;
+
+/**
+ * A manager for controlling BungeeCord networks.
+ */
+public class BungeeManager {
+
+    private final ChannelBinding.RawDataChannel channel;
+
+    public BungeeManager() {
+        this.channel = Sponge.getGame().getChannelRegistrar().createRawChannel(BlockJamCorePlugin.instance(), "BungeeCord");
+    }
+
+    /**
+     * Transfers the given {@link Player} to the given server.
+     *
+     * @param player The player to transfer
+     * @param server The server to transfer the {@link Player} to
+     */
+    public void transferPlayer(Player player, String server) {
+        checkNotNull(this.channel, "channel is null!");
+        checkNotNull(player, "player is null!");
+        checkNotNull(server, "server is null!");
+        this.channel.sendTo(player, buf -> buf.writeUTF("Connect").writeUTF(server));
+    }
+
+}

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -27,9 +27,12 @@ package org.blockjam.core.bungee;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.blockjam.core.BlockJamCorePlugin;
+import org.spongepowered.api.Platform;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.network.ChannelBinding;
+
+import java.util.function.IntConsumer;
 
 /**
  * A manager for controlling BungeeCord networks.
@@ -85,6 +88,34 @@ public class BungeeManager {
     public void transferAllPlayers(BungeeServers server) {
         checkNotNull(server, "server is null!");
         this.transferAllPlayers(server.toString());
+    }
+
+    /**
+     * Gets the player count for the given server.
+     *
+     * @param server The server
+     * @param consumer The consumer for the player count
+     */
+    public void getPlayerCount(String server, IntConsumer consumer) {
+        checkNotNull(server, "server is null!");
+        checkNotNull(consumer, "consumer is null!");
+        this.channel.addListener(Platform.Type.SERVER, (data, connection, side) -> {
+            if (data.readUTF().equalsIgnoreCase(server)) {
+                consumer.accept(data.readInteger());
+            }
+        });
+        this.channel.sendTo(Sponge.getServer().getOnlinePlayers().iterator().next(), buf -> buf.writeUTF("PlayerCount").writeUTF(server));
+    }
+
+    /**
+     * Gets the player count for the given {@link BungeeServers}.
+     *
+     * @param server The server
+     * @param consumer The consumer for the player count
+     */
+    public void getPlayerCount(BungeeServers server, IntConsumer consumer) {
+        checkNotNull(server, "server is null!");
+        this.getPlayerCount(server.toString(), consumer);
     }
 
     /**

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -31,6 +31,8 @@ import org.spongepowered.api.Platform;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.network.ChannelBinding;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.serializer.TextSerializers;
 
 import java.util.function.IntConsumer;
 
@@ -129,6 +131,18 @@ public class BungeeManager {
         checkNotNull(player, "player is null!");
         checkNotNull(reason, "reason is null!");
         this.channel.sendTo(player, buf -> buf.writeUTF("KickPlayer").writeUTF(player.getName()).writeUTF(reason));
+    }
+
+    /**
+     * Kicks the given {@link Player} for the given reason.
+     *
+     * @param player The player to kick from the network
+     * @param reason The reason
+     */
+    public void kickPlayer(Player player, Text reason) {
+        checkNotNull(player, "player is null!");
+        checkNotNull(reason, "reason is null!");
+        this.kickPlayer(player, TextSerializers.LEGACY_FORMATTING_CODE.serialize(reason));
     }
 
 }

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -55,4 +55,15 @@ public class BungeeManager {
         this.channel.sendTo(player, buf -> buf.writeUTF("Connect").writeUTF(server));
     }
 
+    /**
+     * Transfers all online {@link Player}s to the given server.
+     *
+     * @param server The server to transfer the {@link Player}s to
+     */
+    public void transferAllPlayers(String server) {
+        checkNotNull(this.channel, "channel is null!");
+        checkNotNull(server, "server is null!");
+        this.channel.sendToAll(buf -> buf.writeUTF("Connect").writeUTF(server));
+    }
+
 }

--- a/src/main/java/org/blockjam/core/bungee/BungeeManager.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeManager.java
@@ -56,6 +56,17 @@ public class BungeeManager {
     }
 
     /**
+     * Transfers the given {@link Player} to the given {@link BungeeServers}.
+     *
+     * @param player The player to transfer
+     * @param server The server to transfer the {@link Player} to
+     */
+    public void transferPlayer(Player player, BungeeServers server) {
+        checkNotNull(server, "server is null!");
+        this.transferPlayer(player, server.toString());
+    }
+
+    /**
      * Transfers all online {@link Player}s to the given server.
      *
      * @param server The server to transfer the {@link Player}s to
@@ -64,6 +75,29 @@ public class BungeeManager {
         checkNotNull(this.channel, "channel is null!");
         checkNotNull(server, "server is null!");
         this.channel.sendToAll(buf -> buf.writeUTF("Connect").writeUTF(server));
+    }
+
+    /**
+     * Transfers all online {@link Player}s to the given {@link BungeeServers}.
+     *
+     * @param server The server to transfer the {@link Player}s to
+     */
+    public void transferAllPlayers(BungeeServers server) {
+        checkNotNull(server, "server is null!");
+        this.transferAllPlayers(server.toString());
+    }
+
+    /**
+     * Kicks the given {@link Player} for the given reason.
+     *
+     * @param player The player to kick from the network
+     * @param reason The reason
+     */
+    public void kickPlayer(Player player, String reason) {
+        checkNotNull(this.channel, "channel is null!");
+        checkNotNull(player, "player is null!");
+        checkNotNull(reason, "reason is null!");
+        this.channel.sendTo(player, buf -> buf.writeUTF("KickPlayer").writeUTF(player.getName()).writeUTF(reason));
     }
 
 }

--- a/src/main/java/org/blockjam/core/bungee/BungeeServers.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeServers.java
@@ -43,4 +43,5 @@ public enum BungeeServers {
     public String toString() {
         return this.id;
     }
+
 }

--- a/src/main/java/org/blockjam/core/bungee/BungeeServers.java
+++ b/src/main/java/org/blockjam/core/bungee/BungeeServers.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of BlockJamCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, BlockJam <https://blockjam.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.blockjam.core.bungee;
+
+/**
+ * An enumeration of the base servers within the BlockJam network.
+ */
+public enum BungeeServers {
+
+    HUB("hub"),
+    AUDITORIUM("auditorium"),
+    ;
+
+    private final String id;
+
+    BungeeServers(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return this.id;
+    }
+}


### PR DESCRIPTION
Seeing as (according to simon816) only one plugin can register to a `ChannelBinding` it got me thinking... 'how about an abstraction for controlling a BungeeCord network?' so here it is.
## Explanation

BungeeCord uses plugin channels to allow the individual servers to do things (like transferring players, getting the ip of a player, etc) as [documented on Spigot's wiki](https://www.spigotmc.org/wiki/bukkit-bungee-plugin-messaging-channel/) (albeit documented for Bukkit -_-).

This manager allows (or will allow) for us to programmatically use the BungeeCord plugin channel. For example we can now do `BlockJamCorePlugin.bungeeManager().transferPlayer(player, "hub")` as opposed to manually writing to the channel binding.
