### PR TITLE
Deserialize DataSerializables

### DIFF
--- a/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
+++ b/src/main/java/org/blockjam/core/BlockJamCorePlugin.java
@@ -24,12 +24,13 @@
 
 package org.blockjam.core;
 
-import com.google.inject.Inject;
-import ninja.leaping.configurate.commented.CommentedConfigurationNode;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
 import org.blockjam.core.bungee.BungeeManager;
 import org.blockjam.core.config.ConfigKeys;
 import org.blockjam.core.config.ConfigManager;
+
+import com.google.inject.Inject;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;

--- a/src/main/java/org/blockjam/core/config/ConfigManager.java
+++ b/src/main/java/org/blockjam/core/config/ConfigManager.java
@@ -24,6 +24,8 @@
 
 package org.blockjam.core.config;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -32,8 +34,6 @@ import java.nio.file.Files;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A manager for the configuration.

--- a/src/main/java/org/blockjam/core/config/ConfigManager.java
+++ b/src/main/java/org/blockjam/core/config/ConfigManager.java
@@ -27,9 +27,6 @@ package org.blockjam.core.config;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.data.DataSerializable;
-import org.spongepowered.api.data.persistence.DataTranslators;
 
 import java.io.File;
 import java.io.IOException;
@@ -66,37 +63,27 @@ public class ConfigManager {
     }
 
     /**
-     * @return The config value
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T get(ConfigKey<T> key) {
-        return (T) getNode(key).getValue();
-    }
-
-    /**
-     * @return The {@link DataSerializable} of type T
-     */
-    @SuppressWarnings("unchecked")
-    public <T extends DataSerializable> T get(ConfigKey<T> key, Class<T> classOfT) {
-        return Sponge.getDataManager()
-                .deserialize(classOfT, DataTranslators.CONFIGURATION_NODE.translate(getNode(key)))
-                .orElseThrow(() -> new RuntimeException("Couldn't deserialize DataSerializable!"));
-    }
-
-    /**
      * @return The requested node; Node#getValue() may return null if a value is not set
      */
-    private ConfigurationNode getNodeUnsafe(ConfigKey key) {
+    public ConfigurationNode getNodeUnsafe(ConfigKey key) {
         return this.config.getNode((Object[]) key.getPath());
     }
 
     /**
      * @return The requested node; Node#getValue() is definitely non-null
      */
-    private ConfigurationNode getNode(ConfigKey key) {
+    public ConfigurationNode getNode(ConfigKey key) {
         ConfigurationNode node = getNodeUnsafe(key);
         checkNotNull(node.getValue(), "Cannot retrieve non-existent config key!");
         return node;
+    }
+
+    /**
+     * @return The config value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(ConfigKey<T> key) {
+        return (T) getNode(key).getValue();
     }
 
 }

--- a/src/main/java/org/blockjam/core/config/ConfigManager.java
+++ b/src/main/java/org/blockjam/core/config/ConfigManager.java
@@ -24,14 +24,14 @@
 
 package org.blockjam.core.config;
 
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -63,6 +63,9 @@ public class ConfigManager {
     }
 
     /**
+     * Returns the bare {@link ConfigurationNode} without checking if it contains a value.
+     *
+     * @param key The {@link ConfigKey} to get
      * @return The requested node; Node#getValue() may return null if a value is not set
      */
     public ConfigurationNode getNodeUnsafe(ConfigKey key) {
@@ -70,7 +73,10 @@ public class ConfigManager {
     }
 
     /**
-     * @return The requested node; Node#getValue() is definitely non-null
+     * Returns the bare {@link ConfigurationNode} which definitely is non-null.
+     *
+     * @param key The {@link ConfigKey} to get
+     * @return The requested node; Node#getValue() definitely is non-null
      */
     public ConfigurationNode getNode(ConfigKey key) {
         ConfigurationNode node = getNodeUnsafe(key);
@@ -79,6 +85,9 @@ public class ConfigManager {
     }
 
     /**
+     * Returns the value of type T from the config.
+     *
+     * @param key The {@link ConfigKey} to get
      * @return The config value
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/blockjam/core/config/ConfigManager.java
+++ b/src/main/java/org/blockjam/core/config/ConfigManager.java
@@ -24,7 +24,6 @@
 
 package org.blockjam.core.config;
 
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import ninja.leaping.configurate.ConfigurationNode;

--- a/src/main/java/org/blockjam/core/config/ConfigManager.java
+++ b/src/main/java/org/blockjam/core/config/ConfigManager.java
@@ -24,16 +24,17 @@
 
 package org.blockjam.core.config;
 
+
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
 
 /**
  * A manager for the configuration.

--- a/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
+++ b/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, BlockJam - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+
+package org.blockjam.core.config;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.persistence.DataTranslators;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DataSerializableHelper {
+
+    /**
+     * Deserializes a {@link ConfigurationNode} to a {@link DataSerializable}.
+     * @param node The {@link ConfigurationNode} to deserialize
+     * @return The deserialized {@link DataSerializable} of type T
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends DataSerializable> T deserializeNode(Class<T> classOfT, ConfigurationNode node) {
+        return Sponge.getDataManager()
+                .deserialize(classOfT, DataTranslators.CONFIGURATION_NODE.translate(node))
+                .orElseThrow(() -> new RuntimeException(("Couldn't deserialize DataSerializable!")));
+    }
+
+    /**
+     * Deserializes the children of a {@link ConfigurationNode} to a List of {@link DataSerializable}.
+     * @param node The {@link ConfigurationNode} to deserialize
+     * @return The deserialized List of {@link DataSerializable} of type T
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends DataSerializable> List<T> deserializeListNode(Class<T> classOfT, ConfigurationNode node) {
+        return node.getChildrenList()
+                .stream()
+                .map(n -> DataSerializableHelper.deserializeNode(classOfT, n))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
+++ b/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
@@ -24,14 +24,13 @@
 
 package org.blockjam.core.config;
 
+import ninja.leaping.configurate.ConfigurationNode;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.persistence.DataTranslators;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import ninja.leaping.configurate.ConfigurationNode;
 
 public final class DataSerializableHelper {
 

--- a/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
+++ b/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
@@ -1,18 +1,37 @@
 /*
- * Copyright (c) 2016, BlockJam - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
+ * This file is part of BlockJamCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, BlockJam <https://blockjam.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 package org.blockjam.core.config;
 
-import ninja.leaping.configurate.ConfigurationNode;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.persistence.DataTranslators;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import ninja.leaping.configurate.ConfigurationNode;
 
 public class DataSerializableHelper {
 

--- a/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
+++ b/src/main/java/org/blockjam/core/config/DataSerializableHelper.java
@@ -33,10 +33,11 @@ import java.util.stream.Collectors;
 
 import ninja.leaping.configurate.ConfigurationNode;
 
-public class DataSerializableHelper {
+public final class DataSerializableHelper {
 
     /**
      * Deserializes a {@link ConfigurationNode} to a {@link DataSerializable}.
+     *
      * @param node The {@link ConfigurationNode} to deserialize
      * @return The deserialized {@link DataSerializable} of type T
      */
@@ -49,6 +50,7 @@ public class DataSerializableHelper {
 
     /**
      * Deserializes the children of a {@link ConfigurationNode} to a List of {@link DataSerializable}.
+     *
      * @param node The {@link ConfigurationNode} to deserialize
      * @return The deserialized List of {@link DataSerializable} of type T
      */


### PR DESCRIPTION
DataSerializables can now be deserialized from the config.

Example:

``` java
List<ItemStack> itemStacks = DataSerializableHelper
                            .deserializeListNode(ItemStack.class, config().getNode(ConfigKeys.QUICK_START_ITEMS));
```
